### PR TITLE
Add branch alias from dev-master to 0.1.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,10 @@
     },
     "autoload": {
         "psr-4": {"Harp\\Core\\": "src/"}
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.1.x-dev"
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "7c4e3a5dbde8d857cc86e66e3d34e3c7",
+    "hash": "0c3071bd16940f2595a518cf2cbaedab",
     "packages": [
         {
             "name": "harp-orm/serializer",
-            "version": "dev-master",
+            "version": "0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/harp-orm/serializer.git",
-                "reference": "e9cbdf5903a223916f01e8184aa584cd5f136966"
+                "reference": "1cbef206aa54cfc79dc4051d8bdc62d15681db93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/harp-orm/serializer/zipball/e9cbdf5903a223916f01e8184aa584cd5f136966",
-                "reference": "e9cbdf5903a223916f01e8184aa584cd5f136966",
+                "url": "https://api.github.com/repos/harp-orm/serializer/zipball/1cbef206aa54cfc79dc4051d8bdc62d15681db93",
+                "reference": "1cbef206aa54cfc79dc4051d8bdc62d15681db93",
                 "shasum": ""
             },
             "type": "library",
@@ -39,7 +39,7 @@
                 }
             ],
             "description": "Serialize object properties",
-            "time": "2014-06-19 13:03:14"
+            "time": "2014-06-21 17:01:33"
         },
         {
             "name": "harp-orm/util",
@@ -78,22 +78,22 @@
         },
         {
             "name": "harp-orm/validate",
-            "version": "dev-master",
+            "version": "0.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/harp-orm/validate.git",
-                "reference": "db2f10f46a0a822526e1dcbc9c6a4ae413a8537e"
+                "reference": "64166fda5e80f652955c806925da63fc77778cfd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/harp-orm/validate/zipball/db2f10f46a0a822526e1dcbc9c6a4ae413a8537e",
-                "reference": "db2f10f46a0a822526e1dcbc9c6a4ae413a8537e",
+                "url": "https://api.github.com/repos/harp-orm/validate/zipball/64166fda5e80f652955c806925da63fc77778cfd",
+                "reference": "64166fda5e80f652955c806925da63fc77778cfd",
                 "shasum": ""
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Harp\\Validate\\": "src/"
+                    "CL\\Carpo\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -109,7 +109,7 @@
                 }
             ],
             "description": "Object validaiton library",
-            "time": "2014-06-17 14:10:40"
+            "time": "2014-03-17 11:01:22"
         }
     ],
     "packages-dev": [
@@ -189,8 +189,6 @@
     ],
     "minimum-stability": "stable",
     "stability-flags": {
-        "harp-orm/validate": 20,
-        "harp-orm/serializer": 20,
         "clippings/phpunit-extensions": 20
     },
     "platform": {


### PR DESCRIPTION
This is a best practice described here: https://getcomposer.org/doc/articles/aliases.md

I hope it would resolve the problem with requiring `dev-master` from one package and `0.1.*` from another one.

This problem is described in the Composer docs with:

> If anyone wants to require the latest dev-master, they have a problem: Other packages may require `1.0.*`, so requiring that dev version will lead to conflicts, since dev-master does not match the `1.0.*` constraint.
